### PR TITLE
Memoize parameter and secret properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@
 Streamlined, efficient access to configuration values in AWS SSM Parameter Store and SecretsManager.
 
 ## Description
-* Immediate access to available parameters and secrets 
-* Reduce development overhead for Python applications running on AWS
-* Maintain least-privileged permissions to parameters and secrets
+When building Python applications in AWS, it is common to use SSM Parameter Store and SecretsManager to store configuration values. This library provides a simple interface to access these values in a way that is fast, efficient, and secure. It will perform lazy loading for all available parameters or secrets, meaning it will only make API calls when a value is requested:
+- When parameter or secret property is accessed, it first checks if the value has been computed before (cached). If it has, it immediately returns that cached value.
+- If the value hasn't been computed before, it fetches the value and then returns it. This means that your Python app is only calling the AWS API when it needs to.
+
+### Advantages
+* Fast, simple interface to configuration values that can reduce development overhead when working with SSM Parameter Store and SecretsManager
+* Immediate access to available parameters and secrets through intellisense, `map` or `list` methods
+* Maintain least-privileged permissions to parameters and secrets using path-based access control
 
 ## Quickstart
 Install the library using pip.
@@ -15,30 +20,38 @@ Install the library using pip.
 pip install -i https://test.pypi.org/simple/ aws-parameters
 ```
 
-<!-- Export the AWS region to the environment.
-```bash
-export AWS_REGION=<region>
-```
+## Environment Setup
 
-Send JSON data to various AWS services.
+### Methods of Access
+There are 3 methods of accessing SSM Parameters and SecretsManager Secrets values using `aws-parameters.`
+1. From JSON file or object (fastest, does not make additional API calls)
+2. From API Methods `describe-parameters` or `list-secrets` (second fastest)
+3. From deployed SSM Parameter mapping (slowest but least error prone, makes two additional API calls and parses responses)
+
+#### JSON File or Object
+
+### AWS API Methods
+
+### SSM Parameter Mapping
+
+## Usage
+See [Methods of Access](#methods-of-access) for the different ways to setup the environment and access SSM Parameters and SecretsManager Secrets values.
+
+### SSM Parameter Mapping
 ```python
-from awsjsondataset import AwsJsonDataset
+from awsparameters import AppConfig
 
-# create a list of JSON objects
-data = [ {"id": idx, "data": "<data>"} for idx in range(100) ]
+# (optional) Create a boto3 session
+session = boto3.Session(region_name=AWS_REGION)
 
-# Wrap using AwsJsonDataset
-dataset = AwsJsonDataset(data=data)
+# Define the parameter mappings path
+config_path = f"/{APP_NAME}/{STAGE}/{AWS_REGION}/GfedbInfrastructureParamMappings"
 
-# Send to SQS queue
-dataset.sqs("<sqs_queue_url>").send_messages()
-
-# Send to SNS topic
-dataset.sns("<sns_topic_arn>").publish_messages()
-
-# Send to Kinesis Firehose stream
-dataset.firehose("<delivery_stream_name>").put_records()
-``` -->
+# Create the AppConfig object from the mappings path
+app = AppConfig(
+    mapping_path=infra_config_path, 
+    boto3_session=session)
+```
 
 ## Local Development
 Follow the steps to set up the deployment environment.

--- a/awsparameters/manager.py
+++ b/awsparameters/manager.py
@@ -24,6 +24,7 @@ def get_parameter_value(ssm_client, parameter_path: str) -> str:
 
 @lru_cache
 def get_secret_value(secretsmanager_client, secret_id: str) -> str:
+    logger.info(f"Getting secret {secret_id}")
     return secretsmanager_client.get_secret_value(SecretId=secret_id)["SecretString"]
 
 
@@ -82,59 +83,59 @@ class SessionManager:
     def __getattr__(self, name):
         return getattr(self.session, name)
 
-
-# TODO instantiate the variables as empty attributes and then fetch them on demand so that intellisense works
+# TODO self.__class__ will make new attributes available to ALL class instances
+# so ssm params will show up in the class for secrets
+# solutions
+# 1) Declare self.__class__ on a high level class for Params or Secrets that in inherits from ConfigManager
+# so that the attributes are only available to those classes
+# 2) Try reading from a dict where values are initialized as None and then populated on first access
 class ConfigManager(JsonModel):
     def __init__(self, **kwargs) -> None:
         self._service = kwargs["service"]
         self._attr_map = kwargs["attr_map"]
         self._client = kwargs["client"]
 
-    def __getattr__(self, name: str) -> Union[str, dict, list, int, float, bool]:
-        """Fetches and caches values from SSM Parameter Store or Secrets Manager. Will not fetch the same value twice.
+        for name in self._attr_map.keys():
+            setattr(self, f'_{name}', None)  # storing initial None values in "_name" attributes
+            getter = self.make_getter(name)
+            setattr(self.__class__, name, property(getter))  # create properties for each attribute
 
-        Args:
-            name (str): Name of the parameter or secret to fetch
+        print("")
 
-        Raises:
-            ValueError: Bad value for service type
-            AttributeError: Parameter or secret not found
+    def make_getter(self, name):
+        def getter(instance):
+            if instance.__dict__[f'_{name}'] is None:  # check if the corresponding "_name" attribute is None
+                if instance._service == "ssm":
+                    value = get_parameter_value(instance._client, instance._attr_map[name])
+                elif instance._service == "secretsmanager":
+                    value = get_secret_value(instance._client, instance._attr_map[name])
+                else:
+                    raise ValueError(f"Service {instance._service} not supported, must be one of 'ssm' or 'secretsmanager'")
 
-        Returns:
-            Union[str, dict, list, int, float, bool]: Value of the parameter or secret
-        """
-        if name in self._attr_map.keys() and name not in self.__dict__.keys():
-            if self._service == "ssm":
-                value = get_parameter_value(
-                    self._client, self._attr_map[name]
-                )
-            elif self._service == "secretsmanager":
-                value = get_secret_value(
-                    self._client, self._attr_map[name]
-                )
-            else:
-                raise ValueError(
-                    f"Service {self._service} not supported, must be one of 'ssm' or 'secretsmanager'"
-                )
+                # detect json
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError:
+                    pass
 
-            # detect json
-            try:
-                value = json.loads(value)
-            except json.JSONDecodeError:
-                pass
-
-            setattr(self, name, value)
-            return value
-        else:
-            raise AttributeError(f"Could not find '{name}' in {self._service} mapping")
+                instance.__dict__[f'_{name}'] = value  # store the value in "_name" attribute
+            return instance.__dict__[f'_{name}']
+        return getter
 
     def list(self):
         return list(self._attr_map.values())
 
     def __str__(self) -> str:
-        return json.dumps({k: v for k, v in self.__dict__.items() if k != "_client"})
+        return json.dumps({k: v for k, v in self.__dict__.items() if not k.startswith('_') and k != "client"})
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
 
 
+# TODO support for retrieving all params under a path (this circumvents the need for deploying a mapping parameter)
 class AppConfig:
     """Class to manage the configuration of the application using SSM Parameter Store and Secrets Manager.
 
@@ -155,20 +156,20 @@ class AppConfig:
 
     def __init__(
         self,
-        mapping_path: str = None,
+        mappings_path: str = None,
         path_separator: str = "/",
         boto3_session=None,
         region_name: str = None,
         **kwargs,
     ) -> None:
-        self.mapping_path = mapping_path
+        self.mappings_path = mappings_path
         self.session = SessionManager(
             boto3_session,
             region_name,
             get_clients=["ssm"])
     
         self.ssm_paths, self.secrets_paths = \
-            self._load_service_mappings() if mapping_path else \
+            self._load_service_mappings() if mappings_path else \
             (kwargs["ssm_paths"], kwargs["secrets_paths"])
         
         self.services, self._attr_map = self._build_attr_mappings(
@@ -191,7 +192,7 @@ class AppConfig:
 
     def _load_service_mappings(self) -> Tuple[dict, dict]:
         service_mappings = json.loads(self.session.clients["ssm"].get_parameter(
-            Name=self.mapping_path,
+            Name=self.mappings_path,
         )["Parameter"]["Value"])
         return service_mappings.get("ssm", None), service_mappings.get("secretsmanager", None)
 
@@ -210,7 +211,7 @@ class AppConfig:
         for name, mapping in collections.items():
             mappings[name] = \
             {
-                camel_to_snake(item.split(kwargs.get("path_separator"))[-1]): item for item in mapping
+                item.split(kwargs.get("path_separator"))[-1]: item for item in mapping
             }
         return services, mappings
 


### PR DESCRIPTION
## Description
Added lazy loading for all available parameters or secrets, meaning the ConfigManager class will only make API calls when a value is requested:
- When parameter or secret property is accessed, it first checks if the value has been computed before (cached). If it has, it immediately returns that cached value.
- If the value hasn't been computed before, it fetches the value and then returns it. This means that your Python app is only calling the AWS API when it needs to.

**Note:** Using a debugger to inspect the `self` object may cause all parameters to be fetched.